### PR TITLE
Validator

### DIFF
--- a/scraper_Api/company/serializers.py
+++ b/scraper_Api/company/serializers.py
@@ -21,7 +21,7 @@ class CompanySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Company
-        fields = ['company', 'scname', 'website',
+        fields = ['id', 'company', 'scname', 'website',
                   'description', 'logo', 'source','jobsCount', 'published_jobs', 'have_access', 'source_name', 'source_logo']
 
     def create(self, validated_data):

--- a/scraper_Api/company/serializers.py
+++ b/scraper_Api/company/serializers.py
@@ -25,8 +25,9 @@ class CompanySerializer(serializers.ModelSerializer):
                   'description', 'logo', 'source','jobsCount', 'published_jobs', 'have_access', 'source_name', 'source_logo']
 
     def create(self, validated_data):
-        instance, create = Company.objects.get_or_create(**validated_data)
-        if create:
+        instance = Company.objects.filter(**validated_data).first()
+        if not instance:
+            instance = Company.objects.create(**validated_data)
             superusers = CustomUser.objects.filter(is_superuser=True)
             for user in superusers:
                 user.company.add(instance)

--- a/scraper_Api/company/views.py
+++ b/scraper_Api/company/views.py
@@ -129,6 +129,7 @@ class DeleteCompany(APIView):
 
 
 class ClearCompany(APIView):
+
     def post(self, request):
         company = request.data.get("company")
         user = request.user
@@ -159,7 +160,8 @@ class ClearCompany(APIView):
 
 
 class DataSetView(APIView):
-    def get(self, request, company):
+    def get(self, request, id):
+        company = Company.objects.filter(id=id).first()
         company = request.user.company.filter(company=company).first()
 
         if not company:
@@ -173,3 +175,5 @@ class DataSetView(APIView):
 
         serializer = DataSetSerializer(data, many=True)
         return Response(serializer.data)
+
+

--- a/scraper_Api/jobs/views.py
+++ b/scraper_Api/jobs/views.py
@@ -164,15 +164,15 @@ class GetJobData(APIView):
     pagination_class = CustomPagination
 
     def get(self, request):
-        company = request.GET.get("company",)
+        company_id = request.GET.get("id",)
         search = request.GET.get("search") or ""
         order_query = request.GET.get("order") or "all"
         order_by = JOB_SORT_OPTIONS.get(order_query)
         user = request.user
         user_companies = user.company.all()
 
-        if user_companies.filter(company=company.title()).exists():
-            company = get_object_or_404(Company, company=company.title())
+        if user_companies.filter(id=company_id).exists():
+            company = get_object_or_404(Company, id=company_id)
             queryset = Job.objects.filter(
                 company=company.id, job_title__icontains=search
             ).order_by(order_by)

--- a/scraper_Api/jobs/views.py
+++ b/scraper_Api/jobs/views.py
@@ -127,7 +127,7 @@ class AddScraperJobs(APIView, JobView):
 
             current_date = datetime.now()
 
-            company_instance = Company.objects.get(company=company)
+            company_instance = Company.objects.filter(company=company).first()
             jobs = Job.objects.filter(company=company_instance).count()
 
             DataSet.objects.update_or_create(


### PR DESCRIPTION
This pull request updates how companies are referenced and retrieved throughout the API, shifting from using the company name to using the company ID. This change improves data consistency and reduces the risk of errors due to duplicate or similar company names. Additionally, the company serializer and related queries have been updated for better reliability.

**Company reference and retrieval improvements:**

* Updated the `CompanySerializer` to include the `id` field in its output and changed the `create` method to use `.filter().first()` instead of `get_or_create`, ensuring only one instance is created and avoiding duplicate entries.
* Modified the `DataSetView` and `GetJobData` API views to use the company `id` instead of the company name when querying for companies, making lookups more robust and less error-prone. [[1]](diffhunk://#diff-ec51c12f35b055774ea0f50a8f1c65673f8f4840ad956799cc2883466ccecd29L162-R164) [[2]](diffhunk://#diff-53f5808d226358490cca7d98b33f5dec3e9b93766579e402db4e7c036fb842d9L167-R175)
* Updated job creation logic to use `.filter().first()` for fetching the company instance by name, improving safety in cases where multiple companies might have the same name.

**Minor code quality and formatting:**

* Added a blank line for readability in the `ClearCompany` API view.
* Added extra newlines after the response in `DataSetView` for improved code formatting.