### PR TITLE
feat: Update URL patterns and serializer fields for improved job and company handling

### DIFF
--- a/scraper_Api/company/urls.py
+++ b/scraper_Api/company/urls.py
@@ -8,5 +8,5 @@ urlpatterns = [
     path('update/', views.UpdateCompany.as_view()),
     path('delete/', views.DeleteCompany.as_view()),
     path('clear/', views.ClearCompany.as_view()),
-    path('dataset/<company>/', DataSet.as_view()),
+    path('dataset/<id>/', DataSet.as_view()),
 ]

--- a/scraper_Api/jobs/serializer.py
+++ b/scraper_Api/jobs/serializer.py
@@ -56,7 +56,7 @@ class GetJobSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Job
-        fields = ['job_link', 'job_title', 'company', 'country', 'city',
+        fields = ['id','job_link', 'job_title', 'company', 'country', 'city',
                   'county', 'remote', 'edited', 'published', 'posted', 'company_name']
 
     def get_company_name(self, obj):


### PR DESCRIPTION
This pull request updates how companies and jobs are referenced throughout the API, shifting from using company names to using company IDs for improved consistency and reliability. It also adds job IDs and company IDs to job data serialization and transformation, and fixes related queries and lookups to use these IDs.

**Company and Job Reference Updates:**

* Changed the `DataSet` endpoint in `urls.py` to use `id` instead of `company` for more consistent company identification.
* Updated job transformation logic to include `id` and `companyId` fields in job objects, ensuring these identifiers are available for downstream processes.
* Modified job deletion and synchronization logic to query companies by `id` instead of `company` name, and to use company IDs in job lookups, reducing ambiguity and potential errors. [[1]](diffhunk://#diff-53f5808d226358490cca7d98b33f5dec3e9b93766579e402db4e7c036fb842d9L230-R232) [[2]](diffhunk://#diff-53f5808d226358490cca7d98b33f5dec3e9b93766579e402db4e7c036fb842d9R249-R259) [[3]](diffhunk://#diff-53f5808d226358490cca7d98b33f5dec3e9b93766579e402db4e7c036fb842d9L285-R289)

**Serialization Improvements:**

* Added the `id` field to the `GetJobSerializer`, so job objects returned by the API now include their unique identifier.

**Debugging Enhancements:**

* Added print statements to aid debugging in job transformation and synchronization processes. [[1]](diffhunk://#diff-53f5808d226358490cca7d98b33f5dec3e9b93766579e402db4e7c036fb842d9R249-R259) [[2]](diffhunk://#diff-53f5808d226358490cca7d98b33f5dec3e9b93766579e402db4e7c036fb842d9R280)