### PR TITLE
feat: Add CheckSavedJobsView for validating saved job IDs and improve  URL routing

### DIFF
--- a/scraper_Api/mobile/urls.py
+++ b/scraper_Api/mobile/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import GetJobView, GetTotalJobs, GetCompanies
+from .views import GetJobView, GetTotalJobs, GetCompanies, CheckSavedJobsView
 
 urlpatterns = [
     path('', GetJobView.as_view(), name='jobs'),
     path('companies/', GetCompanies.as_view(), name='companies'),
-    path('total/', GetTotalJobs.as_view(), name='total_jobs')
+    path('total/', GetTotalJobs.as_view(), name='total_jobs'),
+    path('check-saved/', CheckSavedJobsView.as_view(), name='check_saved_jobs'),
 ]

--- a/scraper_Api/mobile/views.py
+++ b/scraper_Api/mobile/views.py
@@ -5,6 +5,7 @@ from utils.pagination import CustomPagination
 from .serializer import JobSerializer, CompanySerializer
 from rest_framework.decorators import permission_classes
 from rest_framework.permissions import AllowAny
+from rest_framework import status
 
 from jobs.models import Job
 from company.models import Company
@@ -83,3 +84,17 @@ class GetTotalJobs(APIView):
     def get(self, _):
         total_jobs = Job.objects.filter(published=True).count()
         return Response({"total": total_jobs})
+    
+
+@permission_classes([AllowAny])
+class CheckSavedJobsView(APIView):
+    def post(self, request):
+        job_ids = request.data.get("ids", [])
+        
+        if not isinstance(job_ids, list):
+            return Response({"error": "job_ids must be a list."}, status=status.HTTP_400_BAD_REQUEST)
+        
+        existing_jobs = Job.objects.filter(id__in=job_ids, published=True).values_list('id', flat=True)
+        existing_job_ids = list(existing_jobs)
+
+        return Response({"existing_job_ids": existing_job_ids}, status=status.HTTP_200_OK)


### PR DESCRIPTION
This pull request adds a new API endpoint to allow clients to check which job IDs from a provided list are currently published, and makes the necessary updates to support this feature. The main changes are grouped below:

**New API Endpoint for Checking Saved Jobs:**

* Added a new view class `CheckSavedJobsView` to handle POST requests that accept a list of job IDs and return which ones are published (`scraper_Api/mobile/views.py`).
* Registered the new endpoint at `check-saved/` in the URL configuration (`scraper_Api/mobile/urls.py`).

**Supporting Changes:**

* Imported `status` from `rest_framework` to enable returning appropriate HTTP status codes in responses (`scraper_Api/mobile/views.py`).